### PR TITLE
api-eu-endpoint-support

### DIFF
--- a/app/auth.server.ts
+++ b/app/auth.server.ts
@@ -4,10 +4,12 @@ import { sessionStorage } from "~/session.server";
 
 export let authenticator = new Authenticator(sessionStorage);
 
+export const descopeDomain = process.env.CLIENT_ID?.startsWith('Peu') ? 'api.euc1.descope.com' : `api.descope.com`
+
 authenticator.use(
   new DescopeAuthenticator(
     {
-      domain: `api.descope.com`,
+      domain: descopeDomain,
       clientID: process.env.CLIENT_ID || "",
       clientSecret: process.env.CLIENT_SECRET || "",
       callbackURL: process.env.AUTH_CALLBACK_URL || "http://localhost:3000/auth/callback",

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,8 +1,9 @@
 import type { LoaderFunction } from "@remix-run/node";
-import { authenticator } from "~/auth.server";
+import { authenticator, descopeDomain } from "~/auth.server";
 export let loader: LoaderFunction = async ({ request }) => {
 
-   await fetch(`https://api.descope.com/oauth2/v1/logout`);
+
+   await fetch(`https://${descopeDomain}/oauth2/v1/logout`);
 
    await authenticator.logout(request, { redirectTo: "/" });
   };


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust the <code>Authenticator</code> setup to derive <code>descopeDomain</code> and point EU clients (<code>CLIENT_ID</code> starting with <code>Peu</code>) at <code>api.euc1.descope.com</code> for authentication. Keep the logout loader calling <code>/oauth2/v1/logout</code> on that same computed domain so the session termination flow matches the configured endpoint.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>iddo.mayblum@descope.com</td><td>static-var-for-baseurl</td><td>June 25, 2024</td></tr>
<tr><td>chris@descope.com</td><td>removed-hard-coded-val...</td><td>October 04, 2023</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/descope-sample-apps/remix-oauth2-sample-app/3?tool=ast>(Baz)</a>.